### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_STORE
+.venv
+build
+dist
+*.spec


### PR DESCRIPTION
Use this to avoid including compiled gunk in with repo.

Then, after adding, you'll want to delete the following folders:
- build
- dist

And the following file (though, optional, if you instead want to use this spec file for future builds, might want to remove `*.spec` from the `.gitignore` then):
- `Arc Palette.spec`